### PR TITLE
Improve search to support partial word matching with hybrid query strategy

### DIFF
--- a/pkg/repo/search/bleve_test.go
+++ b/pkg/repo/search/bleve_test.go
@@ -234,3 +234,380 @@ func TestBleveEngine_ReopenIndex(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), count)
 }
+
+func TestSplitQueryTerms(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []queryTerm
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "whitespace only",
+			input:    "   \t  ",
+			expected: nil,
+		},
+		{
+			name:  "single word",
+			input: "markdown",
+			expected: []queryTerm{
+				{text: "markdown", phrase: false},
+			},
+		},
+		{
+			name:  "multiple words",
+			input: "getting started guide",
+			expected: []queryTerm{
+				{text: "getting", phrase: false},
+				{text: "started", phrase: false},
+				{text: "guide", phrase: false},
+			},
+		},
+		{
+			name:  "quoted phrase",
+			input: `"getting started"`,
+			expected: []queryTerm{
+				{text: "getting started", phrase: true},
+			},
+		},
+		{
+			name:  "mixed terms and phrases",
+			input: `welcome "getting started" guide`,
+			expected: []queryTerm{
+				{text: "welcome", phrase: false},
+				{text: "getting started", phrase: true},
+				{text: "guide", phrase: false},
+			},
+		},
+		{
+			name:  "unclosed quote",
+			input: `"getting started`,
+			expected: []queryTerm{
+				{text: "getting started", phrase: true},
+			},
+		},
+		{
+			name:     "empty quotes",
+			input:    `""`,
+			expected: nil,
+		},
+		{
+			name:  "extra whitespace between words",
+			input: "  hello   world  ",
+			expected: []queryTerm{
+				{text: "hello", phrase: false},
+				{text: "world", phrase: false},
+			},
+		},
+		{
+			name:  "multiple quoted phrases",
+			input: `"hello world" "foo bar"`,
+			expected: []queryTerm{
+				{text: "hello world", phrase: true},
+				{text: "foo bar", phrase: true},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := splitQueryTerms(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestBleveEngine_SearchPartialWord(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "test.bleve")
+
+	engine, err := NewBleve(indexPath)
+	require.NoError(t, err)
+
+	defer engine.Close()
+
+	doc := core.Document{
+		ID:        "owner/repo/markdown-guide.md",
+		Repo:      "owner/repo",
+		Path:      "markdown-guide.md",
+		Title:     "Markdown Guide",
+		UpdatedAt: time.Now(),
+	}
+
+	err = engine.Index(t.Context(), doc, "This is a comprehensive markdown formatting guide")
+	require.NoError(t, err)
+
+	// Searching for "mark" should match "markdown" via prefix query.
+	results, err := engine.Search(t.Context(), "mark", core.SearchOpts{Limit: 10})
+	require.NoError(t, err)
+	assert.Greater(t, results.Total, uint64(0), "partial word 'mark' should match 'markdown'")
+	assert.Equal(t, "owner/repo/markdown-guide.md", results.Hits[0].ID)
+}
+
+func TestBleveEngine_SearchPartialWordGet(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "test.bleve")
+
+	engine, err := NewBleve(indexPath)
+	require.NoError(t, err)
+
+	defer engine.Close()
+
+	doc := core.Document{
+		ID:        "owner/repo/getting-started.md",
+		Repo:      "owner/repo",
+		Path:      "getting-started.md",
+		Title:     "Getting Started",
+		UpdatedAt: time.Now(),
+	}
+
+	err = engine.Index(t.Context(), doc, "Getting started with the project setup and configuration")
+	require.NoError(t, err)
+
+	// Searching for "get" should match "getting" via prefix query.
+	results, err := engine.Search(t.Context(), "get", core.SearchOpts{Limit: 10})
+	require.NoError(t, err)
+	assert.Greater(t, results.Total, uint64(0), "partial word 'get' should match 'getting'")
+	assert.Equal(t, "owner/repo/getting-started.md", results.Hits[0].ID)
+}
+
+func TestBleveEngine_SearchFuzzyTypo(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "test.bleve")
+
+	engine, err := NewBleve(indexPath)
+	require.NoError(t, err)
+
+	defer engine.Close()
+
+	doc := core.Document{
+		ID:        "owner/repo/markdown-guide.md",
+		Repo:      "owner/repo",
+		Path:      "markdown-guide.md",
+		Title:     "Markdown Guide",
+		UpdatedAt: time.Now(),
+	}
+
+	err = engine.Index(t.Context(), doc, "This is a comprehensive markdown formatting guide")
+	require.NoError(t, err)
+
+	// Searching for "markdwon" (typo) should match "markdown" via fuzzy query.
+	results, err := engine.Search(t.Context(), "markdwon", core.SearchOpts{Limit: 10})
+	require.NoError(t, err)
+	assert.Greater(t, results.Total, uint64(0), "typo 'markdwon' should match 'markdown'")
+	assert.Equal(t, "owner/repo/markdown-guide.md", results.Hits[0].ID)
+}
+
+func TestBleveEngine_SearchQuotedPhrase(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "test.bleve")
+
+	engine, err := NewBleve(indexPath)
+	require.NoError(t, err)
+
+	defer engine.Close()
+
+	doc := core.Document{
+		ID:        "owner/repo/getting-started.md",
+		Repo:      "owner/repo",
+		Path:      "getting-started.md",
+		Title:     "Getting Started Guide",
+		UpdatedAt: time.Now(),
+	}
+
+	err = engine.Index(t.Context(), doc, "Getting started with the project setup and configuration")
+	require.NoError(t, err)
+
+	// Quoted phrase search should match exact phrase.
+	results, err := engine.Search(t.Context(), `"getting started"`, core.SearchOpts{Limit: 10})
+	require.NoError(t, err)
+	assert.Greater(t, results.Total, uint64(0), "quoted phrase 'getting started' should match")
+	assert.Equal(t, "owner/repo/getting-started.md", results.Hits[0].ID)
+}
+
+func TestBleveEngine_SearchMultipleTerms(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "test.bleve")
+
+	engine, err := NewBleve(indexPath)
+	require.NoError(t, err)
+
+	defer engine.Close()
+
+	matchDoc := core.Document{
+		ID:        "owner/repo/markdown-guide.md",
+		Repo:      "owner/repo",
+		Path:      "markdown-guide.md",
+		Title:     "Markdown Formatting Guide",
+		UpdatedAt: time.Now(),
+	}
+
+	noMatchDoc := core.Document{
+		ID:        "owner/repo/intro.md",
+		Repo:      "owner/repo",
+		Path:      "intro.md",
+		Title:     "Introduction",
+		UpdatedAt: time.Now(),
+	}
+
+	err = engine.Index(t.Context(), matchDoc, "Learn markdown formatting for your documents")
+	require.NoError(t, err)
+
+	err = engine.Index(t.Context(), noMatchDoc, "Welcome to the project introduction")
+	require.NoError(t, err)
+
+	// Both terms must match -- only the markdown guide has both "markdown" and "formatting".
+	results, err := engine.Search(t.Context(), "markdown formatting", core.SearchOpts{Limit: 10})
+	require.NoError(t, err)
+	require.Greater(t, results.Total, uint64(0))
+	assert.Equal(t, "owner/repo/markdown-guide.md", results.Hits[0].ID)
+
+	// "markdown introduction" -- no single document contains both terms.
+	results, err = engine.Search(t.Context(), "markdown introduction", core.SearchOpts{Limit: 10})
+	require.NoError(t, err)
+	// Each document only matches one term, so the conjunction should not match either.
+	assert.Equal(t, uint64(0), results.Total, "conjunction of unrelated terms should not match a single document")
+}
+
+func TestBleveEngine_SearchBoostRanking(t *testing.T) {
+	tests := []struct {
+		name        string
+		doc1        core.Document
+		doc1Content string
+		doc2        core.Document
+		doc2Content string
+		query       string
+		expectedID  string
+		reason      string
+	}{
+		{
+			name: "exact match ranks higher than prefix match",
+			doc1: core.Document{
+				ID:        "owner/repo/exact.md",
+				Repo:      "owner/repo",
+				Path:      "exact.md",
+				Title:     "Markdown Reference",
+				UpdatedAt: time.Now(),
+			},
+			doc1Content: "Guide to markdown syntax and features",
+			doc2: core.Document{
+				ID:        "owner/repo/prefix.md",
+				Repo:      "owner/repo",
+				Path:      "prefix.md",
+				Title:     "Markdownlint Setup",
+				UpdatedAt: time.Now(),
+			},
+			doc2Content: "Guide to markdownlint configuration",
+			query:       "markdown",
+			expectedID:  "owner/repo/exact.md",
+			reason:      "exact match should score higher than prefix-only match",
+		},
+		{
+			name: "title match ranks higher than content match",
+			doc1: core.Document{
+				ID:        "owner/repo/title.md",
+				Repo:      "owner/repo",
+				Path:      "title.md",
+				Title:     "Markdown Reference",
+				UpdatedAt: time.Now(),
+			},
+			doc1Content: "A general reference document",
+			doc2: core.Document{
+				ID:        "owner/repo/content.md",
+				Repo:      "owner/repo",
+				Path:      "content.md",
+				Title:     "Reference Guide",
+				UpdatedAt: time.Now(),
+			},
+			doc2Content: "This explains markdown syntax in detail",
+			query:       "markdown",
+			expectedID:  "owner/repo/title.md",
+			reason:      "title match should score higher than content-only match",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			indexPath := filepath.Join(tmpDir, "test.bleve")
+
+			engine, err := NewBleve(indexPath)
+			require.NoError(t, err)
+
+			defer engine.Close()
+
+			err = engine.Index(t.Context(), tc.doc1, tc.doc1Content)
+			require.NoError(t, err)
+
+			err = engine.Index(t.Context(), tc.doc2, tc.doc2Content)
+			require.NoError(t, err)
+
+			results, err := engine.Search(t.Context(), tc.query, core.SearchOpts{Limit: 10})
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(results.Hits), 2, "both documents should match")
+
+			assert.Equal(t, tc.expectedID, results.Hits[0].ID, tc.reason)
+		})
+	}
+}
+
+func TestBleveEngine_SearchEmptyQuery(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "test.bleve")
+
+	engine, err := NewBleve(indexPath)
+	require.NoError(t, err)
+
+	defer engine.Close()
+
+	doc := core.Document{
+		ID:        "owner/repo/doc.md",
+		Repo:      "owner/repo",
+		Path:      "doc.md",
+		Title:     "Test Doc",
+		UpdatedAt: time.Now(),
+	}
+
+	err = engine.Index(t.Context(), doc, "Some content here")
+	require.NoError(t, err)
+
+	// Empty query should return no results (MatchNoneQuery).
+	results, err := engine.Search(t.Context(), "", core.SearchOpts{Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), results.Total)
+
+	// Whitespace-only query should also return no results.
+	results, err = engine.Search(t.Context(), "   ", core.SearchOpts{Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), results.Total)
+}
+
+func TestBleveEngine_SearchHighlightingWorks(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "test.bleve")
+
+	engine, err := NewBleve(indexPath)
+	require.NoError(t, err)
+
+	defer engine.Close()
+
+	doc := core.Document{
+		ID:        "owner/repo/highlighted.md",
+		Repo:      "owner/repo",
+		Path:      "highlighted.md",
+		Title:     "Highlighted Document",
+		UpdatedAt: time.Now(),
+	}
+
+	err = engine.Index(t.Context(), doc, "This document contains markdown formatting examples")
+	require.NoError(t, err)
+
+	results, err := engine.Search(t.Context(), "markdown", core.SearchOpts{Limit: 10})
+	require.NoError(t, err)
+	require.NotEmpty(t, results.Hits)
+	assert.NotEmpty(t, results.Hits[0].Fragments, "search results should include highlight fragments")
+}


### PR DESCRIPTION
## Summary

- Replace `QueryStringQuery` with a hybrid query combining `MatchQuery`, `PrefixQuery`, and `FuzzyQuery` per search term, enabling partial word matching, typo tolerance, and exact phrase search
- Add field-specific boosting so title matches rank higher than content matches, and exact matches rank higher than prefix/fuzzy matches
- Add comprehensive test coverage for all new search behaviors (partial words, fuzzy typos, quoted phrases, multi-term conjunction, boost ranking, highlighting)

## Details

This is a **query-time only** change — no index schema modifications or re-indexing required.

### Query construction strategy

For each user-input term, a `DisjunctionQuery` is built combining:

| Query Type | Title Boost | Content Boost | Condition |
|---|---|---|---|
| `MatchQuery` | 6.0 | 3.0 | Always |
| `PrefixQuery` | 3.0 | 1.5 | Always |
| `FuzzyQuery` | 1.0 | 0.5 | Term length ≥ 4 |

For quoted phrases, `MatchPhraseQuery` is used (title: 10.0, content: 5.0).

Multiple terms are combined with `ConjunctionQuery` so all terms must match.

Fuzzy edit distance scales: 1 for terms < 7 chars, 2 for longer terms.

### Acceptance criteria (from #15)

- [x] Searching for `mark` returns documents containing `markdown`
- [x] Searching for `get` returns documents containing `getting`
- [x] Searching for `markdwon` (typo) returns documents containing `markdown`
- [x] Full word searches continue to work as before
- [x] Exact phrase searches still work (e.g., `"getting started"`)
- [x] Search highlighting continues to work correctly
- [x] Existing tests pass; new tests cover partial and fuzzy matching scenarios

Closes #15