### PR TITLE
Make repo name clickable in document page breadcrumb

### DIFF
--- a/pkg/views/templates.go
+++ b/pkg/views/templates.go
@@ -82,7 +82,7 @@ const docContentBody = `
         <div class="mb-4 text-sm text-gray-500">
             <a href="/" hx-get="/" hx-target="#main-content" hx-push-url="true" class="hover:text-blue-600">Home</a>
             <span class="mx-1">/</span>
-            <span>{{.Doc.Repo}}</span>
+            <a href="/docs/{{.Doc.Repo}}/" hx-get="/docs/{{.Doc.Repo}}/" hx-target="#main-content" hx-push-url="true" class="hover:text-blue-600">{{.Doc.Repo}}</a>
             <span class="mx-1">/</span>
             <span>{{.Doc.Path}}</span>
         </div>


### PR DESCRIPTION
## Summary

- Replace plain `<span>` with a clickable `<a>` tag for the repo name in the document page breadcrumb (`pkg/views/templates.go:85`)
- Links to the repo index page (`/docs/{owner}/{repo}/`) with HTMX attributes (`hx-get`, `hx-target`, `hx-push-url`) for SPA navigation
- Repo index page breadcrumb is unchanged — repo name stays as plain text since the user is already on that page

Closes #19