### PR TITLE
Updates mit client to supports reconnects

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,7 +76,8 @@ jobs:
       environment_vars: |
         {
           "OMNIDEX_VERSION": "${{ needs.build-and-push.outputs.version }}",
-          "NETWORK_NAME": "omnidex-network"
+          "NETWORK_NAME": "omnidex-network",
+          "MIT_CLIENT_VERSION": "${{ vars.MIT_CLIENT_VERSION }}"
         }
     secrets:
       ssh_key: ${{ secrets.SSH_KEY }}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -41,7 +41,7 @@ services:
         delay: 5s
 
   mit-client:
-    image: "ghcr.io/ksysoev/make-it-public:latest"
+    image: "ghcr.io/ksysoev/make-it-public:v0.8.2"
     environment:
       - EXPOSE=omnidex:8080
       - TOKEN=${MIT_TOKEN}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -41,7 +41,7 @@ services:
         delay: 5s
 
   mit-client:
-    image: "ghcr.io/ksysoev/make-it-public:v0.8.2"
+    image: "ghcr.io/ksysoev/make-it-public:${MIT_CLIENT_VERSION:-latest}"
     environment:
       - EXPOSE=omnidex:8080
       - TOKEN=${MIT_TOKEN}


### PR DESCRIPTION
This pull request updates the `mit-client` service in the Docker Compose configuration to use a specific tagged image version instead of the `latest` tag. This change helps ensure deployments are more predictable and reproducible.

- Docker Compose configuration:
  * Updated the `mit-client` service image from `latest` to the specific version `v0.8.2` in `deploy/docker-compose.yml`