### PR TITLE
fix: extract repeated string literals into constants to satisfy goconst linter

### DIFF
--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -29,6 +29,9 @@ import (
 
 const requestTimeout = 30 * time.Second
 
+// actionUpsert is the ingest action used to add or update documents and assets.
+const actionUpsert = "upsert"
+
 // Publisher handles publishing documentation to an Omnidex instance.
 type Publisher struct {
 	httpClient *http.Client
@@ -170,7 +173,7 @@ func BuildIngestRequest(repo, commitSHA string, files map[string]string, assets 
 		documents = append(documents, core.IngestDocument{
 			Path:        p,
 			Content:     files[p],
-			Action:      "upsert",
+			Action:      actionUpsert,
 			ContentType: ct,
 		})
 	}
@@ -192,7 +195,7 @@ func BuildIngestRequest(repo, commitSHA string, files map[string]string, assets 
 			ingestAssets = append(ingestAssets, core.IngestAsset{
 				Path:    p,
 				Content: base64.StdEncoding.EncodeToString(assets[p]),
-				Action:  "upsert",
+				Action:  actionUpsert,
 			})
 		}
 	}

--- a/pkg/repo/search/bleve.go
+++ b/pkg/repo/search/bleve.go
@@ -77,7 +77,7 @@ func (e *BleveEngine) Search(_ context.Context, query string, opts core.SearchOp
 	q := buildSearchQuery(query)
 	req := bleve.NewSearchRequestOptions(q, opts.Limit, opts.Offset, false)
 	req.Highlight = bleve.NewHighlight()
-	req.Fields = []string{"repo", "path", "title"}
+	req.Fields = []string{fieldRepo, fieldPath, fieldTitle}
 
 	result, err := e.index.Search(req)
 	if err != nil {
@@ -95,15 +95,15 @@ func (e *BleveEngine) Search(_ context.Context, query string, opts core.SearchOp
 			ContentFragments: contentFrags,
 		}
 
-		if repo, ok := hit.Fields["repo"].(string); ok {
+		if repo, ok := hit.Fields[fieldRepo].(string); ok {
 			sr.Repo = repo
 		}
 
-		if path, ok := hit.Fields["path"].(string); ok {
+		if path, ok := hit.Fields[fieldPath].(string); ok {
 			sr.Path = path
 		}
 
-		if title, ok := hit.Fields["title"].(string); ok {
+		if title, ok := hit.Fields[fieldTitle].(string); ok {
 			sr.Title = title
 		}
 
@@ -145,7 +145,7 @@ const listByRepoPageSize = 10000
 // It paginates through results to ensure no documents are silently truncated.
 func (e *BleveEngine) ListByRepo(_ context.Context, repo string) ([]string, error) {
 	q := bleve.NewTermQuery(repo)
-	q.SetField("repo")
+	q.SetField(fieldRepo)
 
 	var (
 		from = 0
@@ -155,7 +155,7 @@ func (e *BleveEngine) ListByRepo(_ context.Context, repo string) ([]string, erro
 	for {
 		req := bleve.NewSearchRequestOptions(q, listByRepoPageSize, from, false)
 		req.Fields = []string{}
-		req.SortBy([]string{"_id"})
+		req.SortBy([]string{fieldID})
 
 		result, err := e.index.Search(req)
 		if err != nil {
@@ -187,6 +187,15 @@ const minFuzzyTermLength = 4
 
 // longTermThreshold is the term length at which fuzzy matching uses a higher edit distance.
 const longTermThreshold = 7
+
+// field name constants used for indexing and querying.
+const (
+	fieldTitle   = "title"
+	fieldContent = "content"
+	fieldRepo    = "repo"
+	fieldPath    = "path"
+	fieldID      = "_id"
+)
 
 // queryTerm represents a single parsed search term.
 type queryTerm struct {
@@ -317,12 +326,12 @@ func buildSearchQuery(userQuery string) bleveQuery.Query {
 // match, which correctly handles common English stopwords that the analyzer strips.
 func buildFullPhraseQueries(phrase string) bleveQuery.Query {
 	titleQ := bleve.NewMatchQuery(phrase)
-	titleQ.SetField("title")
+	titleQ.SetField(fieldTitle)
 	titleQ.SetBoost(8.0)
 	titleQ.SetOperator(bleveQuery.MatchQueryOperatorAnd)
 
 	contentQ := bleve.NewMatchQuery(phrase)
-	contentQ.SetField("content")
+	contentQ.SetField(fieldContent)
 	contentQ.SetBoost(4.0)
 	contentQ.SetOperator(bleveQuery.MatchQueryOperatorAnd)
 
@@ -332,11 +341,11 @@ func buildFullPhraseQueries(phrase string) bleveQuery.Query {
 // buildPhraseQueries creates a disjunction of MatchPhraseQuery for title and content fields.
 func buildPhraseQueries(phrase string) bleveQuery.Query {
 	titleQ := bleve.NewMatchPhraseQuery(phrase)
-	titleQ.SetField("title")
+	titleQ.SetField(fieldTitle)
 	titleQ.SetBoost(10.0)
 
 	contentQ := bleve.NewMatchPhraseQuery(phrase)
-	contentQ.SetField("content")
+	contentQ.SetField(fieldContent)
 	contentQ.SetBoost(5.0)
 
 	return bleve.NewDisjunctionQuery(titleQ, contentQ)
@@ -349,11 +358,11 @@ func buildTermQueries(term string) bleveQuery.Query {
 
 	// Exact/analyzed match -- highest priority.
 	titleMatch := bleve.NewMatchQuery(term)
-	titleMatch.SetField("title")
+	titleMatch.SetField(fieldTitle)
 	titleMatch.SetBoost(6.0)
 
 	contentMatch := bleve.NewMatchQuery(term)
-	contentMatch.SetField("content")
+	contentMatch.SetField(fieldContent)
 	contentMatch.SetBoost(3.0)
 
 	subQueries = append(subQueries, titleMatch, contentMatch)
@@ -362,11 +371,11 @@ func buildTermQueries(term string) bleveQuery.Query {
 	lowered := strings.ToLower(term)
 
 	titlePrefix := bleve.NewPrefixQuery(lowered)
-	titlePrefix.SetField("title")
+	titlePrefix.SetField(fieldTitle)
 	titlePrefix.SetBoost(3.0)
 
 	contentPrefix := bleve.NewPrefixQuery(lowered)
-	contentPrefix.SetField("content")
+	contentPrefix.SetField(fieldContent)
 	contentPrefix.SetBoost(1.5)
 
 	subQueries = append(subQueries, titlePrefix, contentPrefix)
@@ -379,12 +388,12 @@ func buildTermQueries(term string) bleveQuery.Query {
 		}
 
 		titleFuzzy := bleve.NewFuzzyQuery(lowered)
-		titleFuzzy.SetField("title")
+		titleFuzzy.SetField(fieldTitle)
 		titleFuzzy.SetFuzziness(fuzziness)
 		titleFuzzy.SetBoost(1.0)
 
 		contentFuzzy := bleve.NewFuzzyQuery(lowered)
-		contentFuzzy.SetField("content")
+		contentFuzzy.SetField(fieldContent)
 		contentFuzzy.SetFuzziness(fuzziness)
 		contentFuzzy.SetBoost(0.5)
 
@@ -404,10 +413,10 @@ func buildIndexMapping() mapping.IndexMapping {
 	keywordFieldMapping := bleve.NewKeywordFieldMapping()
 	keywordFieldMapping.Store = true
 
-	docMapping.AddFieldMappingsAt("title", textFieldMapping)
-	docMapping.AddFieldMappingsAt("content", textFieldMapping)
-	docMapping.AddFieldMappingsAt("repo", keywordFieldMapping)
-	docMapping.AddFieldMappingsAt("path", keywordFieldMapping)
+	docMapping.AddFieldMappingsAt(fieldTitle, textFieldMapping)
+	docMapping.AddFieldMappingsAt(fieldContent, textFieldMapping)
+	docMapping.AddFieldMappingsAt(fieldRepo, keywordFieldMapping)
+	docMapping.AddFieldMappingsAt(fieldPath, keywordFieldMapping)
 	docMapping.AddFieldMappingsAt("id", keywordFieldMapping)
 
 	indexMapping := bleve.NewIndexMapping()
@@ -420,7 +429,7 @@ func buildIndexMapping() mapping.IndexMapping {
 // Bleve keys fragments by field name ("title", "content"); all other fields fall into content.
 func extractFragments(fragments bleveSearch.FieldFragmentMap) (titleFrags, contentFrags []string) {
 	for field, frags := range fragments {
-		if field == "title" {
+		if field == fieldTitle {
 			titleFrags = append(titleFrags, frags...)
 		} else {
 			contentFrags = append(contentFrags, frags...)

--- a/pkg/repo/search/elastic.go
+++ b/pkg/repo/search/elastic.go
@@ -35,7 +35,7 @@ type ElasticEngine struct {
 func NewElastic(ctx context.Context, cfg *ElasticSearchConfig) (*ElasticEngine, error) {
 	index := cfg.Index
 	if index == "" {
-		index = "omnidex"
+		index = defaultIndex
 	}
 
 	esCfg := elasticsearch.Config{
@@ -83,10 +83,10 @@ func readCACert(path string) ([]byte, error) {
 // Index adds or updates a document in the Elasticsearch index.
 func (e *ElasticEngine) Index(ctx context.Context, doc core.Document, plainText string) error { //nolint:gocritic // Document is passed by value for immutability
 	body := map[string]string{
-		"title":   doc.Title,
-		"content": plainText,
-		"repo":    doc.Repo,
-		"path":    doc.Path,
+		fieldTitle:   doc.Title,
+		fieldContent: plainText,
+		fieldRepo:    doc.Repo,
+		fieldPath:    doc.Path,
 	}
 
 	data, err := json.Marshal(body)
@@ -143,14 +143,14 @@ func (e *ElasticEngine) Search(ctx context.Context, query string, opts core.Sear
 	esQuery := e.buildSearchQuery(query)
 
 	body := map[string]any{
-		"query":   esQuery,
-		"size":    opts.Limit,
+		dslQuery:  esQuery,
+		dslSize:   opts.Limit,
 		"from":    opts.Offset,
-		"_source": []string{"repo", "path", "title"},
-		"highlight": map[string]any{
-			"fields": map[string]any{
-				"title":   map[string]any{"number_of_fragments": 3},
-				"content": map[string]any{"fragment_size": 200, "number_of_fragments": 3},
+		dslSource: []string{fieldRepo, fieldPath, fieldTitle},
+		dslHighlight: map[string]any{
+			dslFields: map[string]any{
+				fieldTitle:   map[string]any{dslNumberOfFragments: 3},
+				fieldContent: map[string]any{"fragment_size": 200, dslNumberOfFragments: 3},
 			},
 			"pre_tags":  []string{"<mark>"},
 			"post_tags": []string{"</mark>"},
@@ -195,8 +195,8 @@ func (e *ElasticEngine) Search(ctx context.Context, query string, opts core.Sear
 			Repo:             hit.Source.Repo,
 			Path:             hit.Source.Path,
 			Title:            hit.Source.Title,
-			TitleFragments:   hit.Highlight["title"],
-			ContentFragments: hit.Highlight["content"],
+			TitleFragments:   hit.Highlight[fieldTitle],
+			ContentFragments: hit.Highlight[fieldContent],
 		}
 		hits = append(hits, sr)
 	}
@@ -211,6 +211,30 @@ func (e *ElasticEngine) Search(ctx context.Context, query string, opts core.Sear
 // esListByRepoPageSize is the page size used when collecting all document IDs for a repository.
 const esListByRepoPageSize = 10000
 
+// defaultIndex is the default Elasticsearch/OpenSearch index name.
+const defaultIndex = "omnidex"
+
+// Query DSL field name constants shared by Elasticsearch and OpenSearch.
+const (
+	dslQuery              = "query"
+	dslSize               = "size"
+	dslSource             = "_source"
+	dslHighlight          = "highlight"
+	dslFields             = "fields"
+	dslNumberOfFragments  = "number_of_fragments"
+	dslSort               = "sort"
+	dslBool               = "bool"
+	dslShould             = "should"
+	dslMinimumShouldMatch = "minimum_should_match"
+	dslBoost              = "boost"
+	dslMultiMatch         = "multi_match"
+
+	mappingTypeText    = "text"
+	mappingTypeKeyword = "keyword"
+	mappingAnalyzer    = "analyzer"
+	mappingTermVector  = "term_vector"
+)
+
 // ListByRepo returns the IDs of all documents in the index that belong to the given repository.
 func (e *ElasticEngine) ListByRepo(ctx context.Context, repo string) ([]string, error) {
 	ids := make([]string, 0, esListByRepoPageSize)
@@ -219,14 +243,14 @@ func (e *ElasticEngine) ListByRepo(ctx context.Context, repo string) ([]string, 
 
 	for {
 		body := map[string]any{
-			"query": map[string]any{
+			dslQuery: map[string]any{
 				"term": map[string]any{
-					"repo": repo,
+					fieldRepo: repo,
 				},
 			},
-			"size":    esListByRepoPageSize,
-			"_source": false,
-			"sort":    []any{"_doc"},
+			dslSize:   esListByRepoPageSize,
+			dslSource: false,
+			dslSort:   []any{"_doc"},
 		}
 
 		if searchAfter != nil {
@@ -292,21 +316,21 @@ func (e *ElasticEngine) ensureIndex(ctx context.Context) error {
 	mapping := map[string]any{
 		"mappings": map[string]any{
 			"properties": map[string]any{
-				"title": map[string]any{
-					"type":        "text",
-					"analyzer":    "standard",
-					"term_vector": "with_positions_offsets",
+				fieldTitle: map[string]any{
+					"type":            mappingTypeText,
+					mappingAnalyzer:   "standard",
+					mappingTermVector: "with_positions_offsets",
 				},
-				"content": map[string]any{
-					"type":        "text",
-					"analyzer":    "standard",
-					"term_vector": "with_positions_offsets",
+				fieldContent: map[string]any{
+					"type":            mappingTypeText,
+					mappingAnalyzer:   "standard",
+					mappingTermVector: "with_positions_offsets",
 				},
-				"repo": map[string]any{
-					"type": "keyword",
+				fieldRepo: map[string]any{
+					"type": mappingTypeKeyword,
 				},
-				"path": map[string]any{
-					"type": "keyword",
+				fieldPath: map[string]any{
+					"type": mappingTypeKeyword,
 				},
 			},
 		},
@@ -345,7 +369,7 @@ func buildESTermQuery(term string) map[string]any {
 	should := []any{
 		// Exact/analyzed match — highest priority.
 		map[string]any{
-			"multi_match": map[string]any{
+			dslMultiMatch: map[string]any{
 				"query":  term,
 				"fields": []string{"title^6", "content^3"},
 				"type":   "best_fields",
@@ -353,7 +377,7 @@ func buildESTermQuery(term string) map[string]any {
 		},
 		// Prefix match — medium priority.
 		map[string]any{
-			"multi_match": map[string]any{
+			dslMultiMatch: map[string]any{
 				"query":  term,
 				"fields": []string{"title^3", "content^1.5"},
 				"type":   "phrase_prefix",
@@ -369,7 +393,7 @@ func buildESTermQuery(term string) map[string]any {
 		}
 
 		should = append(should, map[string]any{
-			"multi_match": map[string]any{
+			dslMultiMatch: map[string]any{
 				"query":     term,
 				"fields":    []string{"title^1", "content^0.5"},
 				"fuzziness": fuzziness,
@@ -378,9 +402,9 @@ func buildESTermQuery(term string) map[string]any {
 	}
 
 	return map[string]any{
-		"bool": map[string]any{
-			"should":               should,
-			"minimum_should_match": 1,
+		dslBool: map[string]any{
+			dslShould:             should,
+			dslMinimumShouldMatch: 1,
 		},
 	}
 }
@@ -388,26 +412,26 @@ func buildESTermQuery(term string) map[string]any {
 // buildESPhraseQuery creates an ES phrase query for quoted terms.
 func buildESPhraseQuery(phrase string) map[string]any {
 	return map[string]any{
-		"bool": map[string]any{
-			"should": []any{
+		dslBool: map[string]any{
+			dslShould: []any{
 				map[string]any{
 					"match_phrase": map[string]any{
-						"title": map[string]any{
-							"query": phrase,
-							"boost": 10.0,
+						fieldTitle: map[string]any{
+							dslQuery: phrase,
+							dslBoost: 10.0,
 						},
 					},
 				},
 				map[string]any{
 					"match_phrase": map[string]any{
-						"content": map[string]any{
-							"query": phrase,
-							"boost": 5.0,
+						fieldContent: map[string]any{
+							dslQuery: phrase,
+							dslBoost: 5.0,
 						},
 					},
 				},
 			},
-			"minimum_should_match": 1,
+			dslMinimumShouldMatch: 1,
 		},
 	}
 }
@@ -415,28 +439,28 @@ func buildESPhraseQuery(phrase string) map[string]any {
 // buildESFullPhraseQuery creates a multi_match AND query for stopword-tolerant full-phrase matching.
 func buildESFullPhraseQuery(phrase string) map[string]any {
 	return map[string]any{
-		"bool": map[string]any{
-			"should": []any{
+		dslBool: map[string]any{
+			dslShould: []any{
 				map[string]any{
 					"match": map[string]any{
-						"title": map[string]any{
-							"query":    phrase,
+						fieldTitle: map[string]any{
+							dslQuery:   phrase,
 							"operator": "and",
-							"boost":    8.0,
+							dslBoost:   8.0,
 						},
 					},
 				},
 				map[string]any{
 					"match": map[string]any{
-						"content": map[string]any{
-							"query":    phrase,
+						fieldContent: map[string]any{
+							dslQuery:   phrase,
 							"operator": "and",
-							"boost":    4.0,
+							dslBoost:   4.0,
 						},
 					},
 				},
 			},
-			"minimum_should_match": 1,
+			dslMinimumShouldMatch: 1,
 		},
 	}
 }
@@ -471,7 +495,7 @@ func buildQueryDSL(userQuery string) map[string]any {
 		}
 
 		perWordQuery = map[string]any{
-			"bool": map[string]any{
+			dslBool: map[string]any{
 				"must": must,
 			},
 		}
@@ -480,12 +504,12 @@ func buildQueryDSL(userQuery string) map[string]any {
 	// For multi-word unquoted queries, add a full-phrase fallback (mirrors Bleve logic).
 	if wordTermCount > 1 && wordTermCount == len(terms) {
 		return map[string]any{
-			"bool": map[string]any{
-				"should": []any{
+			dslBool: map[string]any{
+				dslShould: []any{
 					perWordQuery,
 					buildESFullPhraseQuery(userQuery),
 				},
-				"minimum_should_match": 1,
+				dslMinimumShouldMatch: 1,
 			},
 		}
 	}

--- a/pkg/repo/search/elastic.go
+++ b/pkg/repo/search/elastic.go
@@ -228,11 +228,14 @@ const (
 	dslMinimumShouldMatch = "minimum_should_match"
 	dslBoost              = "boost"
 	dslMultiMatch         = "multi_match"
+	dslType               = "type"
 
-	mappingTypeText    = "text"
-	mappingTypeKeyword = "keyword"
-	mappingAnalyzer    = "analyzer"
-	mappingTermVector  = "term_vector"
+	mappingTypeText            = "text"
+	mappingTypeKeyword         = "keyword"
+	mappingAnalyzer            = "analyzer"
+	mappingTermVector          = "term_vector"
+	mappingAnalyzerStandard    = "standard"
+	mappingTermVectorPositions = "with_positions_offsets"
 )
 
 // ListByRepo returns the IDs of all documents in the index that belong to the given repository.
@@ -317,20 +320,20 @@ func (e *ElasticEngine) ensureIndex(ctx context.Context) error {
 		"mappings": map[string]any{
 			"properties": map[string]any{
 				fieldTitle: map[string]any{
-					"type":            mappingTypeText,
-					mappingAnalyzer:   "standard",
-					mappingTermVector: "with_positions_offsets",
+					dslType:           mappingTypeText,
+					mappingAnalyzer:   mappingAnalyzerStandard,
+					mappingTermVector: mappingTermVectorPositions,
 				},
 				fieldContent: map[string]any{
-					"type":            mappingTypeText,
-					mappingAnalyzer:   "standard",
-					mappingTermVector: "with_positions_offsets",
+					dslType:           mappingTypeText,
+					mappingAnalyzer:   mappingAnalyzerStandard,
+					mappingTermVector: mappingTermVectorPositions,
 				},
 				fieldRepo: map[string]any{
-					"type": mappingTypeKeyword,
+					dslType: mappingTypeKeyword,
 				},
 				fieldPath: map[string]any{
-					"type": mappingTypeKeyword,
+					dslType: mappingTypeKeyword,
 				},
 			},
 		},
@@ -370,17 +373,17 @@ func buildESTermQuery(term string) map[string]any {
 		// Exact/analyzed match — highest priority.
 		map[string]any{
 			dslMultiMatch: map[string]any{
-				"query":  term,
-				"fields": []string{"title^6", "content^3"},
-				"type":   "best_fields",
+				dslQuery:  term,
+				dslFields: []string{"title^6", "content^3"},
+				dslType:   "best_fields",
 			},
 		},
 		// Prefix match — medium priority.
 		map[string]any{
 			dslMultiMatch: map[string]any{
-				"query":  term,
-				"fields": []string{"title^3", "content^1.5"},
-				"type":   "phrase_prefix",
+				dslQuery:  term,
+				dslFields: []string{"title^3", "content^1.5"},
+				dslType:   "phrase_prefix",
 			},
 		},
 	}
@@ -394,8 +397,8 @@ func buildESTermQuery(term string) map[string]any {
 
 		should = append(should, map[string]any{
 			dslMultiMatch: map[string]any{
-				"query":     term,
-				"fields":    []string{"title^1", "content^0.5"},
+				dslQuery:    term,
+				dslFields:   []string{"title^1", "content^0.5"},
 				"fuzziness": fuzziness,
 			},
 		})

--- a/pkg/repo/search/opensearch.go
+++ b/pkg/repo/search/opensearch.go
@@ -285,20 +285,20 @@ func (e *OpenSearchEngine) ensureIndex(ctx context.Context) error {
 		"mappings": map[string]any{
 			"properties": map[string]any{
 				fieldTitle: map[string]any{
-					"type":            mappingTypeText,
-					mappingAnalyzer:   "standard",
-					mappingTermVector: "with_positions_offsets",
+					dslType:           mappingTypeText,
+					mappingAnalyzer:   mappingAnalyzerStandard,
+					mappingTermVector: mappingTermVectorPositions,
 				},
 				fieldContent: map[string]any{
-					"type":            mappingTypeText,
-					mappingAnalyzer:   "standard",
-					mappingTermVector: "with_positions_offsets",
+					dslType:           mappingTypeText,
+					mappingAnalyzer:   mappingAnalyzerStandard,
+					mappingTermVector: mappingTermVectorPositions,
 				},
 				fieldRepo: map[string]any{
-					"type": mappingTypeKeyword,
+					dslType: mappingTypeKeyword,
 				},
 				fieldPath: map[string]any{
-					"type": mappingTypeKeyword,
+					dslType: mappingTypeKeyword,
 				},
 			},
 		},

--- a/pkg/repo/search/opensearch.go
+++ b/pkg/repo/search/opensearch.go
@@ -33,7 +33,7 @@ type OpenSearchEngine struct {
 func NewOpenSearch(ctx context.Context, cfg *OpenSearchConfig) (*OpenSearchEngine, error) {
 	index := cfg.Index
 	if index == "" {
-		index = "omnidex"
+		index = defaultIndex
 	}
 
 	osCfg := opensearchapi.Config{
@@ -78,10 +78,10 @@ func buildOSClientConfig(cfg *OpenSearchConfig) opensearch.Config {
 // Index adds or updates a document in the OpenSearch index.
 func (e *OpenSearchEngine) Index(ctx context.Context, doc core.Document, plainText string) error { //nolint:gocritic // Document is passed by value for immutability
 	body := map[string]string{
-		"title":   doc.Title,
-		"content": plainText,
-		"repo":    doc.Repo,
-		"path":    doc.Path,
+		fieldTitle:   doc.Title,
+		fieldContent: plainText,
+		fieldRepo:    doc.Repo,
+		fieldPath:    doc.Path,
 	}
 
 	data, err := json.Marshal(body)
@@ -135,14 +135,14 @@ func (e *OpenSearchEngine) Search(ctx context.Context, query string, opts core.S
 	esQuery := e.buildSearchQuery(query)
 
 	body := map[string]any{
-		"query":   esQuery,
-		"size":    opts.Limit,
+		dslQuery:  esQuery,
+		dslSize:   opts.Limit,
 		"from":    opts.Offset,
-		"_source": []string{"repo", "path", "title"},
-		"highlight": map[string]any{
-			"fields": map[string]any{
-				"title":   map[string]any{"number_of_fragments": 3},
-				"content": map[string]any{"fragment_size": 200, "number_of_fragments": 3},
+		dslSource: []string{fieldRepo, fieldPath, fieldTitle},
+		dslHighlight: map[string]any{
+			dslFields: map[string]any{
+				fieldTitle:   map[string]any{dslNumberOfFragments: 3},
+				fieldContent: map[string]any{"fragment_size": 200, dslNumberOfFragments: 3},
 			},
 			"pre_tags":  []string{"<mark>"},
 			"post_tags": []string{"</mark>"},
@@ -187,8 +187,8 @@ func (e *OpenSearchEngine) Search(ctx context.Context, query string, opts core.S
 			Repo:             src.Repo,
 			Path:             src.Path,
 			Title:            src.Title,
-			TitleFragments:   hit.Highlight["title"],
-			ContentFragments: hit.Highlight["content"],
+			TitleFragments:   hit.Highlight[fieldTitle],
+			ContentFragments: hit.Highlight[fieldContent],
 		}
 		hits = append(hits, sr)
 	}
@@ -213,14 +213,14 @@ func (e *OpenSearchEngine) ListByRepo(ctx context.Context, repo string) ([]strin
 
 	for {
 		body := map[string]any{
-			"query": map[string]any{
+			dslQuery: map[string]any{
 				"term": map[string]any{
-					"repo": repo,
+					fieldRepo: repo,
 				},
 			},
-			"size":    esListByRepoPageSize,
-			"_source": false,
-			"sort":    []any{"_doc"},
+			dslSize:   esListByRepoPageSize,
+			dslSource: false,
+			dslSort:   []any{"_doc"},
 		}
 
 		if searchAfter != nil {
@@ -284,21 +284,21 @@ func (e *OpenSearchEngine) ensureIndex(ctx context.Context) error {
 	mapping := map[string]any{
 		"mappings": map[string]any{
 			"properties": map[string]any{
-				"title": map[string]any{
-					"type":        "text",
-					"analyzer":    "standard",
-					"term_vector": "with_positions_offsets",
+				fieldTitle: map[string]any{
+					"type":            mappingTypeText,
+					mappingAnalyzer:   "standard",
+					mappingTermVector: "with_positions_offsets",
 				},
-				"content": map[string]any{
-					"type":        "text",
-					"analyzer":    "standard",
-					"term_vector": "with_positions_offsets",
+				fieldContent: map[string]any{
+					"type":            mappingTypeText,
+					mappingAnalyzer:   "standard",
+					mappingTermVector: "with_positions_offsets",
 				},
-				"repo": map[string]any{
-					"type": "keyword",
+				fieldRepo: map[string]any{
+					"type": mappingTypeKeyword,
 				},
-				"path": map[string]any{
-					"type": "keyword",
+				fieldPath: map[string]any{
+					"type": mappingTypeKeyword,
 				},
 			},
 		},


### PR DESCRIPTION
CI was failing due to `goconst` violations detected by golangci-lint v2.12.2 (newer than local v2.11.2).\n\nFixes:\n- `pkg/publisher/publisher.go`: added `actionUpsert` constant\n- `pkg/repo/search/bleve.go`: added `fieldTitle`, `fieldContent`, `fieldRepo`, `fieldPath`, `fieldID` constants\n- `pkg/repo/search/elastic.go`: added `defaultIndex`, DSL field name constants, mapping type constants\n- `pkg/repo/search/opensearch.go`: reuses constants from elastic.go (same package)