### PR TITLE
chore: update Go version to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY pkg/views/ ./pkg/views/
 
 RUN npm install tailwindcss@3 && npx tailwindcss -i input.css -o style.css --minify
 
-FROM golang:1.24.4-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 ARG VERSION=${VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY pkg/views/ ./pkg/views/
 
 RUN npm install tailwindcss@3 && npx tailwindcss -i input.css -o style.css --minify
 
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 ARG VERSION=${VERSION}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ksysoev/omnidex
 
-go 1.24.4
+go 1.26.3
 
 require (
 	github.com/alecthomas/chroma/v2 v2.23.1


### PR DESCRIPTION
Updates Go version from 1.24.4 to 1.26.3 (latest stable) across:\n- `go.mod` — Go toolchain version\n- `Dockerfile` — builder image\n\nCI already reads the version from `go.mod` via `go-version-file: go.mod`, so no workflow changes needed.